### PR TITLE
Remove redundant python 3, make automatic

### DIFF
--- a/setup/ubuntu-python3-theano-setup.sh
+++ b/setup/ubuntu-python3-theano-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-apt-get install pkg-config libfreetype6-dev python3 python3-pip python3-matplotlib python3-numpy python3-tornado python3-scipy ipython3 ipython3-notebook
+apt-get install -y pkg-config libfreetype6-dev python3-pip python3-matplotlib python3-numpy python3-tornado python3-scipy ipython3 ipython3-notebook
 
 echo "Installing python libraries via pip3..."
 pip3 install theano


### PR DESCRIPTION
Python 3 comes default at `3.4.0` on Ubuntu 14.04 and the -y will skip requiring to press enter
